### PR TITLE
IRAM_ATTR for the tick function

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -6,6 +6,8 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
+#include "esp_attr.h"
+
 /*----------------
  * Dynamic memory
  *----------------*/
@@ -81,7 +83,7 @@
 #define USE_LV_FILESYSTEM       1               /*1: Enable file system (required by images*/
 
 /*Compiler attributes*/
-#define LV_ATTRIBUTE_TICK_INC                 /* Define a custom attribute to tick increment function */
+#define LV_ATTRIBUTE_TICK_INC   IRAM_ATTR     /* Define a custom attribute to tick increment function */
 #define LV_ATTRIBUTE_TASK_HANDLER
 
 /*================

--- a/main/main.c
+++ b/main/main.c
@@ -23,7 +23,7 @@
 #include "../drv/tp_spi.h"
 #include "../drv/xpt2046.h"
 
-static void lv_tick_task(void);
+static void IRAM_ATTR lv_tick_task(void);
 
 void app_main()
 {
@@ -57,7 +57,7 @@ void app_main()
 	}
 }
 
-static void lv_tick_task(void)
+static void IRAM_ATTR lv_tick_task(void)
 {
 	lv_tick_inc(portTICK_RATE_MS);
 }


### PR DESCRIPTION
otherwise the esp32 will crash if cache is disabled (in my case during SPIFFS write).

Also add the attribute to your function:
    static void IRAM_ATTR lv_tick_task(void)